### PR TITLE
Switch to using a builder pattern

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,7 +16,8 @@ module.exports = function (config) {
 
         // list of files / patterns to load in the browser
         files: [
-            '*.test.js'
+            '*.test.js',
+            'lib/**/*.test.js'
         ],
 
 
@@ -27,7 +28,8 @@ module.exports = function (config) {
         // preprocess matching files before serving them to the browser
         // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
         preprocessors: {
-            '*.test.js': ['browserify']
+            '*.test.js': ['browserify'],
+            'lib/**/*.test.js': ['browserify']
         },
 
 

--- a/lib/extensions/passwordmeter.js
+++ b/lib/extensions/passwordmeter.js
@@ -78,21 +78,36 @@ RuleSet.Build(function build (setBuilder) {
         .addRule(function upperCaseLetters(ruleBuilder) {
             return ruleBuilder
                 .withName('upperCaseLetters')
-                .test(regexTest(upperCaseTest))
-                .rate(function(length, hits) { return (length - hits) * 2; })
+                .test(function (input) {
+                    if (consecutiveTest(upperCaseTest)(input) === input.length) {
+                        return 0;
+                    }
+                    return regexTest(upperCaseTest)(input);
+                })
+                .rate(function(length, hits) { return hits ? (length - hits) * 2 : 0; })
                 .build();
         })
         .addRule(function lowerCaseLetters(ruleBuilder) {
             return ruleBuilder
                 .withName('lowerCaseLetters')
-                .test(regexTest(lowerCaseTest))
-                .rate(function(length, hits) { return (length - hits) * 2; })
+                .test(function (input) {
+                    if (consecutiveTest(lowerCaseTest)(input) === input.length) {
+                        return 0;
+                    }
+                    return regexTest(lowerCaseTest)(input);
+                })
+                .rate(function(length, hits) { return hits ? (length - hits) * 2 : 0; })
                 .build();
         })
         .addRule(function numbers(ruleBuilder) {
             return ruleBuilder
                 .withName('numbers')
-                .test(regexTest(numberTest))
+                .test(function (input) {
+                    if (sameTypeTest(numberTest)(input) === input.length) {
+                        return 0;
+                    }
+                    return regexTest(numberTest)(input);
+                })
                 .rate(function (length, hits) { return hits * 4; })
                 .build();
         })
@@ -201,13 +216,15 @@ RuleSet.Build(function build (setBuilder) {
             return ruleBuilder
                 .withName('requirements')
                 .test(function (input) {
+                    input = input.join('');
                     var reqs = [upperCaseTest, lowerCaseTest, numberTest, symbolTest];
-
-                    return reqs.reduce(function (accumulator, testRe) {
-                        return testRe.test(input) ? accumulator + 2 : accumulator;
+                    var points = reqs.reduce(function (accumulator, testRe) {
+                        return testRe.test(input) ? accumulator + 1 : accumulator;
                     }, 0);
+
+                    return input.length < 8 || points < 3 ? 0 : points + 1;
                 })
-                .rate(function (length, hits) { return length >= 8 ? 2 + hits : 0; })
+                .rate(function (length, hits) { return 2 * hits; })
                 .build();
         })
         .build();

--- a/lib/extensions/passwordmeter.js
+++ b/lib/extensions/passwordmeter.js
@@ -1,0 +1,214 @@
+var RuleSet = require('../ruleset');
+
+RuleSet.Build(function build (setBuilder) {
+    var upperCaseTest = /[A-Z]/,
+        lowerCaseTest = /[a-z]/,
+        numberTest = /[0-9]/,
+        symbolTest = /[^A-Za-z0-9]/,
+        numberOrSymbolTest = /[^A-Za-z]/,
+        letterTest = /[A-Za-z]/,
+        seqLetters = 'abcdefghijklmnopqrstuvwxyz'.split(''),
+        seqNumbers = '01234567890'.split(''),
+        seqSymbols = ')!@#$%^&*()'.split('');
+
+    var regexTest = function test(testRe) {
+        return function (input) {
+            return input.reduce(function (accumulator, current) {
+                return testRe.test(current) ? accumulator + 1 : accumulator;
+            }, 0);
+        };
+    };
+
+    var sameTypeTest = function sameType(testRe) {
+        return function (input) {
+            return input.every(function (char) {
+                return testRe.test(char);
+            }) ? input.length : 0;
+        };
+    };
+
+    var consecutiveTest = function consecutive(testRe) {
+        return function (input) {
+            return input.reduce(function (matches, letter, index, letters) {
+                return index > 0 && testRe.test(letter) && testRe.test(letters[index - 1]) ?
+                    matches + 1 : matches;
+            }, 0);
+        };
+    };
+
+    var sequentialTest = function sequential(sequenceMembers, minLengthForSequence) {
+        minLengthForSequence = minLengthForSequence || 3;
+
+        return function (input) {
+            var cursor, index, sequenceIndex, count, length, character, sequenceMember;
+            cursor = count = 0;
+
+            for (cursor = 0; cursor < input.length; cursor++) {
+                index = cursor;
+                character = input[index];
+                sequenceIndex = sequenceMembers.indexOf(character);
+                sequenceMember = sequenceMembers[sequenceIndex];
+                length = 0;
+
+                while (character && character === sequenceMember) {
+                    length = length + 1;
+                    character = input[++index];
+                    sequenceMember = sequenceMembers[++sequenceIndex];
+                }
+
+                count = length >= minLengthForSequence ? count + 1 : count;
+            }
+
+            return count;
+        };
+    };
+
+    return setBuilder
+        .withName('passwordmeter')
+        .beforeRule(function toCharArray(input) {
+            return typeof input === 'string' ? input.split('') : [];
+        })
+        .addRule(function numberOfCharacters(ruleBuilder) {
+            return ruleBuilder
+                .withName('numberOfCharacters')
+                .test(function (input) { return input.length; })
+                .rate(function (length, hits) { return hits * 4; })
+                .build();
+        })
+        .addRule(function upperCaseLetters(ruleBuilder) {
+            return ruleBuilder
+                .withName('upperCaseLetters')
+                .test(regexTest(upperCaseTest))
+                .rate(function(length, hits) { return (length - hits) * 2; })
+                .build();
+        })
+        .addRule(function lowerCaseLetters(ruleBuilder) {
+            return ruleBuilder
+                .withName('lowerCaseLetters')
+                .test(regexTest(lowerCaseTest))
+                .rate(function(length, hits) { return (length - hits) * 2; })
+                .build();
+        })
+        .addRule(function numbers(ruleBuilder) {
+            return ruleBuilder
+                .withName('numbers')
+                .test(regexTest(numberTest))
+                .rate(function (length, hits) { return hits * 4; })
+                .build();
+        })
+        .addRule(function symbols(ruleBuilder) {
+            return ruleBuilder
+                .withName('symbols')
+                .test(regexTest(symbolTest))
+                .rate(function (length, hits) { return hits * 6; })
+                .build();
+        })
+        .addRule(function middleNumbersAndSymbols(ruleBuilder) {
+            return ruleBuilder
+                .withName('middleNumbersAndSymbols')
+                .test(function (input) {
+                    return regexTest(numberOrSymbolTest)(input.slice(1, -1));
+                })
+                .rate(function (length, hits) { return hits * 2; })
+                .build();
+        })
+        .addRule(function lettersOnly(ruleBuilder) {
+            return ruleBuilder
+                .withName('lettersOnly')
+                .test(sameTypeTest(letterTest))
+                .rate(function (length, hits) { return -hits; })
+                .build();
+        })
+        .addRule(function numbersOnly(ruleBuilder) {
+            return ruleBuilder
+                .withName('numbersOnly')
+                .test(sameTypeTest(numberTest))
+                .rate(function (length, hits) { return -hits; })
+                .build();
+        })
+        .addRule(function repeatCharacters(ruleBuilder) {
+            return ruleBuilder
+                .withName('repeatCharacters')
+                .test(function (input) {
+                    var nRepChar = 0;
+
+                    return input.reduce(function (accumulator, aVal, aIndex, arr) {
+                        var nUnqChar;
+
+                        var bTotal = arr.reduce(function (acc, bVal, bIndex) {
+                            return (aVal === bVal && aIndex !== bIndex) ?
+                            acc + Math.abs(arr.length / (bIndex - aIndex)) :
+                                acc;
+                        }, accumulator);
+
+                        if (bTotal !== accumulator) {
+                            nRepChar += 1;
+                            nUnqChar = arr.length - nRepChar;
+
+                            return (nUnqChar) > 0 ?
+                                Math.ceil(bTotal / nUnqChar) :
+                                Math.ceil(bTotal);
+                        }
+                        return accumulator;
+                    }, 0);
+                })
+                .rate(function(length, hits) { return -hits; })
+                .build();
+        })
+        .addRule(function consecutiveUppercase(ruleBuilder) {
+            return ruleBuilder
+                .withName('consecutiveUppercase')
+                .test(consecutiveTest(upperCaseTest))
+                .rate(function (length, hits) { return -2 * hits; })
+                .build();
+        })
+        .addRule(function consecutiveLowercase(ruleBuilder) {
+            return ruleBuilder
+                .withName('consecutiveLowercase')
+                .test(consecutiveTest(lowerCaseTest))
+                .rate(function (length, hits) { return -2 * hits; })
+                .build();
+        })
+        .addRule(function consecutiveNumber(ruleBuilder) {
+            return ruleBuilder
+                .withName('consecutiveNumber')
+                .test(consecutiveTest(numberTest))
+                .rate(function (length, hits) { return -2 * hits; })
+                .build();
+        })
+        .addRule(function sequentialLetters(ruleBuilder) {
+            return ruleBuilder
+                .withName('sequentialLetters')
+                .test(sequentialTest(seqLetters))
+                .rate(function (length, hits) { return -3 * hits; })
+                .build();
+        })
+        .addRule(function sequentialNumbers(ruleBuilder) {
+            return ruleBuilder
+                .withName('sequentialNumbers')
+                .test(sequentialTest(seqNumbers))
+                .rate(function (length, hits) { return -3 * hits; })
+                .build();
+        })
+        .addRule(function sequentialSymbols(ruleBuilder) {
+            return ruleBuilder
+                .withName('sequentialSymbols')
+                .test(sequentialTest(seqSymbols))
+                .rate(function (length, hits) { return -3 * hits; })
+                .build();
+        })
+        .addRule(function requirements(ruleBuilder) {
+            return ruleBuilder
+                .withName('requirements')
+                .test(function (input) {
+                    var reqs = [upperCaseTest, lowerCaseTest, numberTest, symbolTest];
+
+                    return reqs.reduce(function (accumulator, testRe) {
+                        return testRe.test(input) ? accumulator + 2 : accumulator;
+                    }, 0);
+                })
+                .rate(function (length, hits) { return length >= 8 ? 2 + hits : 0; })
+                .build();
+        })
+        .build();
+});

--- a/lib/extensions/passwordmeter.test.js
+++ b/lib/extensions/passwordmeter.test.js
@@ -110,6 +110,7 @@ describe('PasswordStrength', () => {
         describe('consecutive numbers', () => {
             it('should deduct 2 points for every consecutive number', () => {
                 expect(passwordMeter.checkPassword('abcd12').consecutiveNumber).toBe(-2);
+                expect(passwordMeter.checkPassword('12345678910').consecutiveNumber).toEqual(-20);
             });
         });
 
@@ -146,6 +147,10 @@ describe('PasswordStrength', () => {
 
         it('should check this other password', () => {
             expect(passwordMeter.checkPassword('^CHkAV,4gy').score).toEqual(90);
+        });
+
+        it('should use additions and deductions', () => {
+            expect(passwordMeter.checkPassword('12345678910').score).toEqual(9);
         });
     });
 });

--- a/lib/extensions/passwordmeter.test.js
+++ b/lib/extensions/passwordmeter.test.js
@@ -1,0 +1,151 @@
+'use strict';
+
+import 'babel-polyfill';
+
+let PasswordStrength = require('../passwordstrength');
+let passwordMeter = new PasswordStrength();
+passwordMeter.useRuleSet('passwordmeter');
+
+describe('PasswordStrength', () => {
+    describe('additions', () => {
+        describe('number of characters', () => {
+            it('should assign a score of 0 for an undefined value', () => {
+                expect(passwordMeter.checkPassword().numberOfCharacters).toEqual(0);
+            });
+
+            it('should assign as score of n*4 for length', () => {
+                expect(passwordMeter.checkPassword('aa').numberOfCharacters).toEqual(8);
+            });
+        });
+
+        describe('uppercase letters', () => {
+            it('should assign a score of 0 if all the characters are uppercase letters', () => {
+                expect(passwordMeter.checkPassword('AA').upperCaseLetters).toEqual(0);
+            });
+
+            it('should assign a score of +((len-n)*2 for uppercase characters WHEN there is mixed case', () => {
+                expect(passwordMeter.checkPassword('Aa').upperCaseLetters).toBe(2);
+            });
+        });
+
+        describe('lowercase letters', () => {
+            it('should assign a score of 0 if all the characters are lowercase letters', () => {
+                expect(passwordMeter.checkPassword('aa').lowerCaseLetters).toEqual(0);
+            });
+
+            it('should assign a score of +((len-n)*2 for lowercase characters WHEN there is mixed case', () => {
+                expect(passwordMeter.checkPassword('Aa').lowerCaseLetters).toBe(2);
+            });
+        });
+
+        describe('numerical characters', () => {
+            it('should give 4 points per number', () => {
+                expect(passwordMeter.checkPassword('B613').numbers).toEqual(12);
+            });
+        });
+
+        describe('symbols', () => {
+            it('should give 6 points per symbol', () => {
+                expect(passwordMeter.checkPassword('Ke$ha').symbols).toEqual(6);
+            });
+        });
+
+        describe('middle numbers and symbols', () => {
+            it('should assign 0 points to an input with no middle symbols', () => {
+                expect(passwordMeter.checkPassword('a$').middleNumbersAndSymbols).toEqual(0);
+            });
+
+            it('should give 2 points for any number or symbol in the middle of the input', () => {
+                expect(passwordMeter.checkPassword('l33t').middleNumbersAndSymbols).toEqual(4);
+                expect(passwordMeter.checkPassword('fr0z*n').middleNumbersAndSymbols).toEqual(4);
+            });
+        });
+
+        describe('requirements', () => {
+            it('should award 8 points when the length requirement and 3 other requirements are met', () => {
+                expect(passwordMeter.checkPassword('hunkymonkey1@').requirements).toEqual(8);
+            });
+
+            it('should award 10 points when the length requirement and all other requirements are met', () => {
+                expect(passwordMeter.checkPassword('Hunkymonkey1@').requirements).toEqual(10);
+            });
+        });
+    });
+
+    describe('deductions', () => {
+        describe('letters only', () => {
+            it('should subtract one pointer per letter if all the characters are letters', () => {
+                expect(passwordMeter.checkPassword('abEfg').lettersOnly).toEqual(-5);
+            });
+        });
+
+        describe('numbers only', () => {
+            it('should subtract one pointer per letter if all the characters are letters', () => {
+                expect(passwordMeter.checkPassword('12345').numbersOnly).toEqual(-5);
+            });
+        });
+
+        describe('repeat characters', () => {
+            it('should deduct for repeat characters based on proximity', () => {
+                expect(passwordMeter.checkPassword('aa').repeatCharacters).toEqual(-4);
+                expect(passwordMeter.checkPassword('aaa').repeatCharacters).toEqual(-14);
+                expect(passwordMeter.checkPassword('abcdabcd').repeatCharacters).toEqual(-6);
+                expect(passwordMeter.checkPassword('aabbaa').repeatCharacters).toEqual(-24);
+                expect(passwordMeter.checkPassword('blob').repeatCharacters).toEqual(-2);
+            });
+        });
+
+        describe('consecutive upper case', () => {
+            it('should deduct 2 points for every consecutive upper case letter', () => {
+                expect(passwordMeter.checkPassword('AAbCC').consecutiveUppercase).toBe(-4);
+            });
+        });
+
+        describe('consecutive lower case', () => {
+            it('should deduct 2 points for every consecutive lowercase letter', () => {
+                expect(passwordMeter.checkPassword('blah').consecutiveLowercase).toBe(-6);
+            });
+        });
+
+        describe('consecutive numbers', () => {
+            it('should deduct 2 points for every consecutive number', () => {
+                expect(passwordMeter.checkPassword('abcd12').consecutiveNumber).toBe(-2);
+            });
+        });
+
+        describe('sequential letters (3+)', () => {
+            it('should deduct 3 points for every sequence of letters of 3 or more characters', () => {
+                expect(passwordMeter.checkPassword('abc').sequentialLetters).toEqual(-3);
+
+                // jasmine complaining that -0 != 0. wat?
+                expect(Math.abs(passwordMeter.checkPassword('ab12cd').sequentialLetters)).toEqual(0);
+            });
+        });
+
+        describe('sequential numbers (3+)', () => {
+            it('should deduct 3 points for every sequence of numbers of 3 or more characters', () => {
+                expect(passwordMeter.checkPassword('123a45').sequentialNumbers).toEqual(-3);
+            });
+        });
+
+        describe('sequential symbols (3+)', () => {
+            it('should deduct 3 points for every sequence of symbols of 3 or more characters', () => {
+                expect(passwordMeter.checkPassword(')!@#$').sequentialSymbols).toEqual(-9);
+            });
+        });
+    });
+
+    describe('the cumulative effect', () => {
+        it('should check the entire password', () => {
+            expect(passwordMeter.checkPassword('my)Fp43.').score).toEqual(88);
+        });
+
+        it('should cap the output at 100', () => {
+            expect(passwordMeter.checkPassword('j}FnoU8bseRL&X3CbFQWVKW').score).toEqual(100);
+        });
+
+        it('should check this other password', () => {
+            expect(passwordMeter.checkPassword('^CHkAV,4gy').score).toEqual(90);
+        });
+    });
+});

--- a/lib/passwordstrength.js
+++ b/lib/passwordstrength.js
@@ -1,0 +1,31 @@
+var RuleSet = require('./ruleset');
+require('./extensions/passwordmeter');
+
+function PasswordStrength() {
+    this.rules = new RuleSet();
+}
+
+PasswordStrength.prototype.useRuleSet = function useRuleSet(name) {
+    this.rules = RuleSet.get(name);
+    return this;
+};
+
+PasswordStrength.prototype.checkPassword = function(input) {
+    return this.rules.apply(input);
+};
+
+/**
+ * Assigns a numerical value to a password using the default passwordmeter configuration.
+ * Add backwards compatibility with version 1.0.x
+ *
+ * @param  {String}
+ * @return {Number}
+ */
+PasswordStrength.checkPassword = function checkPassword(input) {
+    return new PasswordStrength()
+        .useRuleSet('passwordmeter')
+        .checkPassword(input)
+        .score;
+};
+
+module.exports = PasswordStrength;

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -1,0 +1,9 @@
+function Rule(name, test, rate) {
+    this.name = name;
+
+    this.fn = function check (string) {
+        return rate(string.length, test(string));
+    };
+}
+
+module.exports = Rule;

--- a/lib/rulebuilder.js
+++ b/lib/rulebuilder.js
@@ -1,0 +1,51 @@
+function RuleBuilder() {}
+
+/**
+ * @param  {String} name
+ * @return {RuleBuilder}
+ */
+RuleBuilder.prototype.withName = function(name) {
+    this.name = name;
+    return this;
+};
+
+/**
+ * @callback TestFunction
+ * @param {String} input the password string to test for this rule
+ * @return {Number} the count for this rule (i.e. how many times the test is successful)
+ */
+
+/**
+ * @param  {TestFunction} testFunction
+ * @return {RuleBuilder}
+ */
+RuleBuilder.prototype.test = function(testFunction) {
+    this.testFunction = testFunction;
+    return this;
+};
+
+/**
+ * @callback RateFunction
+ * @param {Number} length number of characters in the input
+ * @param {Number} hits number of occurrences for this rule given by the ruleFunction
+ * @return {Number} the computed strength bonus
+ */
+
+/**
+ * @param  {RateFunction} rateFunction
+ * @return {RuleBuilder}
+ */
+RuleBuilder.prototype.rate = function(rateFunction) {
+    this.rateFunction = rateFunction;
+    return this;
+};
+
+/**
+ * @return {Rule}
+ */
+RuleBuilder.prototype.build = function() {
+    var Rule = require('./rule');
+    return new Rule(this.name, this.testFunction, this.rateFunction);
+};
+
+module.exports = RuleBuilder;

--- a/lib/ruleset.js
+++ b/lib/ruleset.js
@@ -1,0 +1,61 @@
+var knownRuleSets = {};
+
+function RuleSet(name, rules, before) {
+    this.name  = name;
+    this.rules = rules;
+    this.before = before;
+}
+
+/**
+ * @param  {String} input The password to apply this rule set to
+ * @return {Number} The strength determined by this set of rules
+ */
+RuleSet.prototype.apply = function(input) {
+    var result = {};
+
+    if (this.before) {
+        input = this.before(input);
+    }
+
+    result.score = this.rules.reduce(function(score, rule) {
+        result[rule.name] = rule.fn(input);
+        return score + result[rule.name];
+    }, 0);
+
+    // set max score to 100 for all rule sets
+    result.score = Math.min(result.score, 100);
+
+    return result;
+};
+
+/**
+ * @param  {String} name
+ * @return {RuleSet}
+ */
+RuleSet.get = function get(name) {
+    if (name in knownRuleSets) {
+        return knownRuleSets[name];
+    }
+
+    return new RuleSet();
+};
+
+/**
+ * @callback RuleBuilderFunction
+ * @param {RuleSetBuilder} ruleSetBuilder
+ * @returns {RuleSet}
+ */
+
+/**
+ * @param {RuleSetBuilderFunction} builderFunction
+ */
+RuleSet.Build = function Build(builderFunction) {
+    var RuleSetBuilder = require('./rulesetbuilder');
+    var ruleSet = builderFunction(new RuleSetBuilder());
+
+    if (ruleSet instanceof RuleSet) {
+        knownRuleSets[ruleSet.name] = ruleSet;
+    }
+};
+
+module.exports = RuleSet;

--- a/lib/rulesetbuilder.js
+++ b/lib/rulesetbuilder.js
@@ -1,0 +1,59 @@
+function RuleSetBuilder() {
+    this.ruleSet = [];
+}
+
+/**
+ * @param  {String}
+ * @return {RuleSetBuilder}
+ */
+RuleSetBuilder.prototype.withName = function(name) {
+    this.name = name;
+    return this;
+};
+
+/**
+ * @param  {Function.<String>} fn A function to be called on the input before each rule
+ * @return {RuleSetBuilder}
+ */
+RuleSetBuilder.prototype.beforeRule = function(fn) {
+    var beforeFunction = this.beforeFunction;
+
+    this.beforeFunction = function newBeforeFunction(input) {
+        return beforeFunction ? fn(beforeFunction(input)) : fn(input);
+    };
+
+    return this;
+};
+
+/**
+ * @callback RuleBuilderFunction
+ * @param {RuleBuilder} ruleBuilder
+ * @returns {Rule}
+ */
+
+/**
+ * @param {RuleBuilderFunction} builderFunction
+ * @return {RuleSetBuilder}
+ */
+RuleSetBuilder.prototype.addRule = function(builderFunction) {
+    var Rule = require('./rule');
+    var RuleBuilder = require('./rulebuilder');
+    var rule = builderFunction(new RuleBuilder());
+
+    if (rule instanceof Rule) {
+        this.ruleSet.push(rule);
+        return this;
+    }
+
+    throw new Error('Incomplete definition provided for Rule');
+};
+
+/**
+ * @return {RuleSet}
+ */
+RuleSetBuilder.prototype.build = function() {
+    var RuleSet = require('./ruleset');
+    return new RuleSet(this.name, this.ruleSet, this.beforeFunction);
+};
+
+module.exports = RuleSetBuilder;


### PR DESCRIPTION
Probably the fastest way to get a handle on this change is to look at `PasswordStrength.checkPassword` in _lib/passwordstrength.js_ as a starting point and then jump over to _lib/extensions/passwordmeter.js_ to see how the [passwordmeter](http://www.passwordmeter.com/) rule set is built.

My goal was to make this little library easy to extend, so I wanted the rules to be very flexible, easy to author, and the logic not to be too closely tied to what's suggested by passwordmeter, since...

> This application is neither perfect nor foolproof, and should only be utilized as a loose guide in determining methods for improving the password creation process.

I started from a definition: _a string's **password strength** is a numeric value given by applying a set of pre-defined rules to that string_. 

From there, it seemed to make sense to have a concepts for a `Rule` and a `RuleSet` and corresponding builders.

The existing unit tests are all passing, as well as a few extra ones discovered in #6 .
